### PR TITLE
Allow raw uploaders to list files they've uploaded

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -38,6 +38,16 @@ Resources:
               - "s3:PutObject"
             Resource:
               !Join ["", [!GetAtt [WarehouseBucket, Arn], "/raw/*"]]
+          - Effect: Allow
+            Action:
+              - "s3:ListBucket"
+            Resource:
+              !GetAtt [WarehouseBucket, Arn]
+            Condition:
+              ForAllValues:StringLike:
+                "s3:prefix":
+                  - "raw/*"
+
   DataUploaderGroup:
     Type: AWS::IAM::Group
     Properties:


### PR DESCRIPTION
This allows listing the bucket, but only that single bucket within the `raw/` prefix, so even uploaders cannot see the training/validation split. It might be handy for the uploaders to see what's there already.