### PR TITLE
Add group that can view the whole upload bucket, in read-only mode

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -44,6 +44,30 @@ Resources:
       ManagedPolicyArns:
         - !Ref UploadToRawPolicy
 
+  ReadOnlyAccessWholeBucketPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Join ["", ["read-only-", !Ref "BucketNameParameter"]]
+      Description: Allow read-only view of the warehouse bucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - "s3:ListBucket"
+            Resource:
+              !GetAtt [WarehouseBucket, Arn]
+          - Effect: Allow
+            Action:
+              - "s3:GetObject"
+            Resource:
+              !Join ["", [!GetAtt [WarehouseBucket, Arn], "/*"]]
+  DataVerifierGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      ManagedPolicyArns:
+        - !Ref ReadOnlyAccessWholeBucketPolicy
+
   # CloudTrail
   CloudTrailLogsBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
When this policy is attached to the user, they will be able to list, and read from the upload bucket, through it's direct link:

* If console user, then directly through `https://s3.console.aws.amazon.com/s3/buckets/BUCKETNAME/`
* If programmatic access, then through `s3://BUCKETNAME/`

where `BUCKETNAME` is the one created by the template.

Connects-to: #11 
Tested on our faculty development account.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>