### PR TITLE
Allow specifying CIDR blocks from where uploads to "raw/" are allowed

### DIFF
--- a/infrastructure/create.py
+++ b/infrastructure/create.py
@@ -46,6 +46,10 @@ def create_warehouse(suffix=None, allowed_cidr=None):
                 "ParameterValue": ",".join(allowed_cidr),
             }
         ]
+    elif changeset_type == "UPDATE":
+        parameters += [
+            {"ParameterKey": "WarehouseUploadCIDRParameter", "UsePreviousValue": True,}
+        ]
 
     # Submit the change set
     response = CLIENT.create_change_set(

--- a/infrastructure/create.py
+++ b/infrastructure/create.py
@@ -23,7 +23,7 @@ def _stack_exists(stack_name):
     return stack_name in stack_names
 
 
-def create_warehouse(suffix=None):
+def create_warehouse(suffix=None, allowed_cidr=None):
     suffix_string = "" if suffix is None else f"-{suffix}"
     template_body = (TEMPLATES_DIRECTORY / "warehouse.yaml").read_text()
     timestamp_suffix = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
@@ -39,6 +39,14 @@ def create_warehouse(suffix=None):
     parameters = [
         {"ParameterKey": "BucketNameParameter", "ParameterValue": bucket_name}
     ]
+    if allowed_cidr is not None:
+        parameters += [
+            {
+                "ParameterKey": "WarehouseUploadCIDRParameter",
+                "ParameterValue": ",".join(allowed_cidr),
+            }
+        ]
+
     # Submit the change set
     response = CLIENT.create_change_set(
         StackName=stack_name,
@@ -52,14 +60,20 @@ def create_warehouse(suffix=None):
     return changeset_arn
 
 
-def main(suffix=None):
-    changeset_arn = create_warehouse(suffix)
+def main(suffix=None, allowed_cidr=None):
+    changeset_arn = create_warehouse(suffix, allowed_cidr)
     logging.info(f"Created changeset for warehouse with ARN: {changeset_arn}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--suffix", help="suffix to use for templates and names")
+    parser.add_argument(
+        "-a",
+        "--allowed-cidr",
+        action="append",
+        help="allowed CIDR block for 'raw/' uploads, can specify multiple times",
+    )
     args = parser.parse_args()
 
-    main(args.suffix)
+    main(args.suffix, args.allowed_cidr)

--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -3,6 +3,10 @@ Parameters:
     Type: String
     Default: nccid-data-warehouse
     Description: The base name of the storage bucket
+  WarehouseUploadCIDRParameter:
+    Type: CommaDelimitedList
+    Default: "0.0.0.0/0"
+    Description: Comma delimited list of CIDR blocks from where upload to the "raw/" folder is allowed
 
 Resources:
 
@@ -23,6 +27,20 @@ Resources:
         BlockPublicPolicy: true
         RestrictPublicBuckets: true
         IgnorePublicAcls: true
+  WarehouseBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref WarehouseBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Deny
+            Principal: "*"
+            Action: s3:PutObject
+            Resource: !Join ["", [!GetAtt [WarehouseBucket, Arn], "/raw/*"]]
+            Condition:
+              NotIpAddress:
+                aws:SourceIp: !Ref "WarehouseUploadCIDRParameter"
 
   # IAM
   UploadToRawPolicy:


### PR DESCRIPTION
Usage through command line flags at the moment. If no flags are applied,
then all IPs are allowed. Multiple ranges can be provided by adding
the flag multiple times, such as:

```
python create.py -s suffix -a 1.2.3.4/24 -a 5.6.7.8/24
```

By default the upload is not limited (i.e. the value `0.0.0.0/0` is set). In subsequent updates, if no `-a`/`--allowed-cidr` flags are passed, the previous values are used (to make it more difficult to accidentally open up access by not passing the flags).

Connects-to: #9
Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>