### PR TITLE
Add CODEOWNERS, closes #18

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@imrehg @pbugnion


### PR DESCRIPTION
Anyone else should be on this list? @edent for example? (just asking whether preferred, or required at all, though feels definitely optional)

The point of [`CODEOWNERS`](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) is to automatically add specific people as reviewers on PRs, and thus there's smaller number here, so it's more signal and not noise for people.