### PR TITLE
infrastructure: at bucket creation type set allowed CIDR to default value

### DIFF
--- a/infrastructure/create.py
+++ b/infrastructure/create.py
@@ -46,7 +46,16 @@ def create_warehouse(suffix=None, allowed_cidr=None):
                 "ParameterValue": ",".join(allowed_cidr),
             }
         ]
-    elif changeset_type == "UPDATE":
+    elif changeset_type == "CREATE":
+        # If no value specified at creation time
+        parameters += [
+            {
+                "ParameterKey": "WarehouseUploadCIDRParameter",
+                "ParameterValue": "0.0.0.0/0",
+            }
+        ]
+    else:
+        # If no value specified at update time
         parameters += [
             {"ParameterKey": "WarehouseUploadCIDRParameter", "UsePreviousValue": True,}
         ]


### PR DESCRIPTION
## Description

Otherwise it seems the "UsePreviousValue" setting doesn't take "default"
into account as "previous" value.

## Checklist

- [x] Changes have been tested
