### PR TITLE
docs: add extra-footer to link back to the source code, closes #42

### DIFF
--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -1,0 +1,5 @@
+{% extends '!footer.html' %} 
+
+{% block extrafooter %}
+The source code to this site is available on <a href="https://github.com/nhsx/covid-chest-imaging-database/">GitHub</a>.
+{% endblock %}


### PR DESCRIPTION
## Description

To connect easier the site and the source, when people navigate to the page.

## Checklist

- [x] Changes have been tested
