### PR TITLE
docs: update template links to Data and Status formats, closes #55

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,10 +36,9 @@ The categories of data collected are:
 - Outcome data, including time to mechanical ventilation, discharge and death
 
 The full list of clinical data points collected for positive and negative
-patients can found in the documents below:
-
-- `Covid-19 Data (Positive) Template v1.5 (Excel) <https://medphys.royalsurrey.nhs.uk/nccid/guidance/COVID-19_NCCID_covid_positive_data_template_v1_5.xlsx>`_
-- `Covid-19 Status (Negative) Template v1.0 (Excel) <https://medphys.royalsurrey.nhs.uk/nccid/guidance/COVID-19_NCCID_covid_status_negative_data_template_v1_0.xlsx>`_
+patients can found in the template spreadsheets on the
+`Guidance And Documentation For Collection Sites <https://medphys.royalsurrey.nhs.uk/nccid/guidance.php>`_
+page.
 
 
 Data collection


### PR DESCRIPTION
## Description

Instead of hard-linking the positive/negative clinical data template documents, link to their hosting page.

Preview:

<img width="706" alt="Screenshot 2020-05-14 12 20 22" src="https://user-images.githubusercontent.com/38863/81928606-71561780-95dd-11ea-830e-abe317128dc9.png">

## Checklist

- [x] Changes have been tested
