### PR TITLE
infra: relax check on prefix to list training data

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -123,7 +123,6 @@ Resources:
             Condition:
               StringLike:
                 s3:prefix: ["training/ct/*", "training/ct-metadata/*", "training/data/*"]
-                s3:delimiter: "/"
           - Effect: Allow
             Action:
               - "s3:GetObject"
@@ -154,7 +153,6 @@ Resources:
             Condition:
               StringLike:
                 s3:prefix: ["training/mri/*", "training/mri-metadata/*", "training/data/*"]
-                s3:delimiter: "/"
           - Effect: Allow
             Action:
               - "s3:GetObject"
@@ -185,7 +183,6 @@ Resources:
             Condition:
               StringLike:
                 s3:prefix: ["training/x-ray/*", "training/x-ray-metadata/*", "training/data/*"]
-                s3:delimiter: "/"
           - Effect: Allow
             Action:
               - "s3:GetObject"


### PR DESCRIPTION
## Description

If the delimiter is included, `aws sync` cannot work on the training folders, as it doesn't send a delimiter.

Related to https://github.com/aws/aws-cli/issues/5202

## Checklist

- [x] Changes have been tested
