### PR TITLE
structure: rename `x-ray` folder to `xray`

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -182,13 +182,13 @@ Resources:
               !GetAtt [WarehouseBucket, Arn]
             Condition:
               StringLike:
-                s3:prefix: ["training/x-ray/*", "training/x-ray-metadata/*", "training/data/*"]
+                s3:prefix: ["training/xray/*", "training/xray-metadata/*", "training/data/*"]
           - Effect: Allow
             Action:
               - "s3:GetObject"
             Resource:
-              - !Join ["", [!GetAtt [WarehouseBucket, Arn], "/training/x-ray/*"]]
-              - !Join ["", [!GetAtt [WarehouseBucket, Arn], "/training/x-ray-metadata/*"]]
+              - !Join ["", [!GetAtt [WarehouseBucket, Arn], "/training/xray/*"]]
+              - !Join ["", [!GetAtt [WarehouseBucket, Arn], "/training/xray-metadata/*"]]
               - !Join ["", [!GetAtt [WarehouseBucket, Arn], "/training/data/*"]]
   TrainingXrayGroup:
     Type: AWS::IAM::Group

--- a/warehouse-loader/README.md
+++ b/warehouse-loader/README.md
@@ -82,13 +82,13 @@ and date, as follows:
 /training/ct-metadata/PATIENT_ID/IMAGE_UUID.json
 /training/mri/PATIENT_ID/IMAGE_UUID.dcm
 /training/mri-metadata/PATIENT_ID/IMAGE_UUID.json
-/training/x-ray/PATIENT_ID/IMAGE_UUID.dcm
-/training/x-ray-metadata/PATIENT_ID/IMAGE_UUID.json
+/training/xray/PATIENT_ID/IMAGE_UUID.dcm
+/training/xray-metadata/PATIENT_ID/IMAGE_UUID.json
 /training/data/PATIENT_ID/status_DATE.json
 /training/data/PATIENT_ID/data_DATE.json
 ```
 
-* The `ct`, `mri`, `x-ray` folders hold the DICOM images of the relevant kind.
+* The `ct`, `mri`, `xray` folders hold the DICOM images of the relevant kind.
 * The `...-metadata` folders hold the DICOM tags exported as `json` from the corresponding `IMAGE_UUID.dcm`
 * The `data` folder holds the patient medical data, `status_DATE.json` files for negative results, and `data_DATE.json` file/files for positive results. The `DATE` is formatted as `YYYY-MM-DD`, such as `2020-04-21`.
 

--- a/warehouse-loader/warehouseloader.py
+++ b/warehouse-loader/warehouseloader.py
@@ -30,8 +30,8 @@ CONFIG_KEY = "config.json"
 TRAINING_PERCENTAGE = 0
 
 MODALITY = {
-    "DX": "x-ray",
-    "CR": "x-ray",
+    "DX": "xray",
+    "CR": "xray",
     "MR": "mri",
     "CT": "ct",
 }


### PR DESCRIPTION
This is more in line with the `ct` and `mri` folder/prefix names, and clashing less with the `...-metadata` prefix pattern.

## Checklist

- [x] Changes have been tested
