### PR TITLE
infrastructure: change inventory format to CSV and limit fields

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -37,11 +37,9 @@ Resources:
       InventoryConfigurations:
         - Destination:
             BucketArn: !GetAtt [WarehouseInventoryBucket, Arn]
-            Format: Parquet
+            Format: CSV
           OptionalFields:
             - Size
-            - LastModifiedDate
-            - ETag
           Enabled: true
           Id: "daily-full-inventory"
           IncludedObjectVersions: Current


### PR DESCRIPTION
Turns out that inventory files won't really work with S3 Select, as the sizes are grown above the max queryable size. If we need to download the files to work together with anyways, then simpler (and smaller) CSV (Gzip'd by default) should be easier to deal with.

## Checklist

- [x] Changes have been tested
