### PR TITLE
container: add missing explicit dependencies

### DIFF
--- a/infrastructure/container/Dockerfile
+++ b/infrastructure/container/Dockerfile
@@ -4,9 +4,12 @@ FROM phusion/baseimage:18.04-1.0.0
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
       awscli=1.18.69-1ubuntu0.18.04.1 \
+      gcc=4:7.4.0-1ubuntu2.3 \
       git=1:2.17.1-1ubuntu0.7 \
       python3=3.6.7-1~18.04 \
+      python3-dev=3.6.7-1~18.04 \
       python3-pip=9.0.1-2.3~ubuntu1.18.04.1 \
+      python3-setuptools=39.0.1-2 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Installation of the Python code was missing these after recommended packages were removed by the suggestion of the linter.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>


## Checklist

- [x] Changes have been tested
