### PR TITLE
infra: Docker repository to only keep 5 untagged images

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -467,6 +467,21 @@ Resources:
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: !Sub "${AWS::StackName}-pipeline"
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+            {
+              "rulePriority": 1,
+              "description": "Only keep 5 untagged images",
+              "selection": {
+                "tagStatus": "untagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 5
+              },
+              "action": { "type": "expire" }
+            }]
+          }
 
   ECSCluster:
     Type: 'AWS::ECS::Cluster'


### PR DESCRIPTION
When a new "prod" image is tagged, previous versions will be untagged, clean those up over time, or over pushes.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>


## Checklist

- [ ] Changes have been tested
