### PR TITLE
infra: set log retention of pipeline logs

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -586,6 +586,8 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /ecs/${AWS::StackName}-pipeline
+      # 2 years of pipeline run log retention
+      RetentionInDays: 731
 
   PipelineRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Start off with 2 years, that should be on the safe side, even though
we'd be okay with a few months for this particular part.

Closes: #139 
Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>


## Checklist

- [x] Changes have been tested
