### PR TITLE
scaling up pipeline task due to the memory use required

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -587,7 +587,7 @@ Resources:
     Properties:
       RequiresCompatibilities:
         - "FARGATE"
-      Cpu: "512"  # 1 vCPU
+      Cpu: "512"  # 0.5 vCPU
       Memory: "1GB"
       NetworkMode: "awsvpc"
       ExecutionRoleArn: !GetAtt [ECSTaskExecutionRole, Arn]
@@ -620,8 +620,8 @@ Resources:
     Properties:
       RequiresCompatibilities:
         - "FARGATE"
-      Cpu: "1024"  # 1 vCPU
-      Memory: "8GB"
+      Cpu: "2048"  # 2 vCPU
+      Memory: "12GB"
       NetworkMode: "awsvpc"
       ExecutionRoleArn: !GetAtt [ECSTaskExecutionRole, Arn]
       TaskRoleArn: !GetAtt [PipelineRole, Arn]


### PR DESCRIPTION
Current use of Pandas is a bit too much for the given instance sizes, before refactoring, can do a bit of scaling.


## Checklist

- [x] Changes have been tested
