### PR TITLE
container: allow installing from requirements file to pin dependencies

### DIFF
--- a/infrastructure/container/Dockerfile
+++ b/infrastructure/container/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
       git=1:2.17.1-1ubuntu0.7 \
       python3=3.6.7-1~18.04 \
       python3-dev=3.6.7-1~18.04 \
-      python3-pip=9.0.1-2.3~ubuntu1.18.04.2 \
+      python3-pip=9.0.1-2.3~ubuntu1.18.04.4 \
       python3-setuptools=39.0.1-2 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/infrastructure/container/fetch_and_run.sh
+++ b/infrastructure/container/fetch_and_run.sh
@@ -39,6 +39,12 @@ echo "Checking out ${COMMIT}"
 git checkout -b run "${COMMIT}" || error_exit "Failed to check out relevant commitish: ${COMMIT}"
 cd "${CODE_FOLDER}" || error_exit "Failed to enter code folder ${CODE_FOLDER}"
 echo "Installing code & dependencies..."
+if [ -f "requirements.txt" ]; then
+  echo "Found requirements.txt, processing..."
+  python3 -m pip install --user -q -r requirements.txt || error_exit "Failed to install Python dependencies from requirements.txt."
+else
+  echo "No requirements.txt to install..."
+fi
 python3 -m pip install --user -q . || error_exit "Failed to install Python dependencies."
 
 script="${1}"; shift


### PR DESCRIPTION
Otherwise `setup.py` cannot pin dependencies exactly...

## Checklist

- [x] Changes have been tested
