### PR TITLE
workflows: remove no longer necessary step from codeql flow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,11 +22,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
From the logs it showed:

> Warning: 1 issue was detected with this workflow:
> git checkout HEAD^2 is no longer necessary. Please remove
> this step as Code Scanning recommends analyzing the merge
> commit for best results.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>


## Checklist

- [x] Changes have been tested
