### PR TITLE
dashboard: update cloudfront settigns to actually display things correctly

### DIFF
--- a/infrastructure-dashboard/dashboard/dashboard/dashboard_stack.py
+++ b/infrastructure-dashboard/dashboard/dashboard/dashboard_stack.py
@@ -80,9 +80,14 @@ class DashboardStack(core.Stack):
         )
 
         origin = _origins.HttpOrigin(
-            domain_name=fargate_service.load_balancer.load_balancer_dns_name
+            domain_name=fargate_service.load_balancer.load_balancer_dns_name,
+            protocol_policy=_cloudfront.OriginProtocolPolicy.HTTP_ONLY,
         )
-        behaviour = _cloudfront.BehaviorOptions(origin=origin)
+        behaviour = _cloudfront.BehaviorOptions(
+            origin=origin,
+            cache_policy=_cloudfront.CachePolicy.CACHING_DISABLED,
+            viewer_protocol_policy=_cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        )
 
         distribution = _cloudfront.Distribution(
             self,


### PR DESCRIPTION
Matching the connection to the backend as the rest of the load balanced
ECS setup does things, though might be useful to have further improvements
added later (e.g. currently TLS is terminated on Cloudfront, and after that
it's HTTP traffic inside AWS. Ideally all traffic should be HTTPS,
but that will need some load balancer and container changes that are
still to be determined.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>


## Checklist

- [ ] Changes have been tested
