### PR TITLE
Dashboard tuning

### DIFF
--- a/dashboard/dashboard/templates/macros/navbar.html
+++ b/dashboard/dashboard/templates/macros/navbar.html
@@ -1,7 +1,6 @@
 {% macro navbar(active="home", user="") -%}
 <nav class="navbar navbar-expand-md navbar-dark bg-primary">
   <a class="navbar-brand abs" href="/">NCCID Dashboard</a>
-  <span class="badge badge-pill badge-warning" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="This version of the dashboard is in development.">Development</span>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsingNavbar">
       <span class="navbar-toggler-icon"></span>
   </button>

--- a/infrastructure-dashboard/dashboard/dashboard/dashboard_stack.py
+++ b/infrastructure-dashboard/dashboard/dashboard/dashboard_stack.py
@@ -88,6 +88,9 @@ class DashboardStack(core.Stack):
                 },
             },
             platform_version=ecs.FargatePlatformVersion.VERSION1_4,
+            # See values for these entries at https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.aws_ecs_patterns/NetworkLoadBalancedFargateService.html#networkloadbalancedfargateservice
+            cpu=256,  # .25 vCPU
+            memory_limit_mib=512,  # 0.5 GB
         )
 
         processed_bucket = s3.Bucket.from_bucket_name(


### PR DESCRIPTION
* removing the `development` marking from the dashboard header
* making provisioned cpu/memory explicit in the infrastructure, to have it ready to change when/if needed.

## Checklist

- [x] Changes have been tested
