### PR TITLE
loader: submittingcentres results to be included in email notification

### DIFF
--- a/warehouse-loader/bin/submittingcentres
+++ b/warehouse-loader/bin/submittingcentres
@@ -41,9 +41,8 @@ main() {
     runtime=$((end-start))
 
     message="Pipeline run in $(convertsecs $runtime) and exited with code ${exitcode}."
-    echo "${message}"
     # One for SNS the notification, append to existing file or create it
-    echo "\n${message}" >> /tmp/message.txt
+    echo "${message}" | tee -a /tmp/message.txt
 
     # shellcheck disable=SC2153
     if [ -n "${TOPIC_ARN}" ]; then

--- a/warehouse-loader/bin/submittingcentres
+++ b/warehouse-loader/bin/submittingcentres
@@ -42,10 +42,12 @@ main() {
 
     message="Pipeline run in $(convertsecs $runtime) and exited with code ${exitcode}."
     echo "${message}"
+    # One for SNS the notification, append to existing file or create it
+    echo "\n${message}" >> /tmp/message.txt
 
     # shellcheck disable=SC2153
     if [ -n "${TOPIC_ARN}" ]; then
-        send_message "${TOPIC_ARN}" "Pipeline finished - submittingcentres" "$message"
+        send_message "${TOPIC_ARN}" "Pipeline finished - submittingcentres" "file:///tmp/message.txt"
     fi
 }
 


### PR DESCRIPTION
The submittingcentres task saves results to /tmp/message.txt,
add to that the pipeline message, and send the file contents.


## Checklist

- [x] Changes have been tested
