### PR TITLE
workflows: fix container version for hadolint

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,7 +6,7 @@ jobs:
   docker-lint:
     runs-on: ubuntu-latest
 
-    container: hadolint/hadolint
+    container: hadolint/hadolint:v1.23.0-8-gb01c5a9
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub running seems to have issues with latest container image
that also has major version bump it seems.


## Checklist

- [ ] Changes have been tested
