### PR TITLE
loader: pipeline improvements for memory management

### DIFF
--- a/infrastructure/templates/warehouse.yaml
+++ b/infrastructure/templates/warehouse.yaml
@@ -777,7 +777,7 @@ Resources:
       RequiresCompatibilities:
         - "FARGATE"
       Cpu: "1024"  # 1 vCPU
-      Memory: "2GB"
+      Memory: "8GB"
       NetworkMode: "awsvpc"
       ExecutionRoleArn: !GetAtt [ECSTaskExecutionRole, Arn]
       TaskRoleArn: !GetAtt [PipelineRole, Arn]

--- a/warehouse-loader/warehouse/warehouseloader.py
+++ b/warehouse-loader/warehouse/warehouseloader.py
@@ -396,7 +396,7 @@ def upload_text_data(*args, s3client):
         and outgoing_data is not None
     ):
         if DRY_RUN:
-            logger.debug(f"Would upload to key: {outgoing_key}")
+            logger.info(f"Would upload to key: {outgoing_key}")
         else:
             s3client.put_object(key=outgoing_key, content=outgoing_data)
 
@@ -516,7 +516,7 @@ def data_copy(*args, s3client):
     ) = args
     if task == "copy" and old_key is not None and new_key is not None:
         if DRY_RUN:
-            logger.debug(f"Would copy: {old_key} -> {new_key}")
+            logger.info(f"Would copy: {old_key} -> {new_key}")
         else:
             s3client.copy_object(old_key, new_key)
 

--- a/warehouse-loader/warehouse/warehouseloader.py
+++ b/warehouse-loader/warehouse/warehouseloader.py
@@ -21,6 +21,7 @@ from warehouse.components import constants, helpers, services
 # set up logging
 mondrian.setup(excepthook=True)
 logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 BUCKET_NAME = os.getenv("WAREHOUSE_BUCKET", default=None)
 DRY_RUN = bool(os.getenv("DRY_RUN", default=False))
@@ -234,9 +235,11 @@ def extract_raw_files_from_folder(config, filelist):
     """
     raw_prefixes = {prefix.rstrip("/") for prefix in config.get_raw_prefixes()}
     # List the clinical data files for processing
+    logger.info("Starting on clinical data file processing.")
     for key in filelist.get_raw_data_list(raw_prefixes=raw_prefixes):
         yield "process", key, None
     # List the unprocessed image files for processing
+    logger.info("Starting on image file processing.")
     for key in filelist.get_pending_raw_images_list(raw_prefixes=raw_prefixes):
         yield "process", key, None
 
@@ -393,7 +396,7 @@ def upload_text_data(*args, s3client):
         and outgoing_data is not None
     ):
         if DRY_RUN:
-            logger.info(f"Would upload to key: {outgoing_key}")
+            logger.debug(f"Would upload to key: {outgoing_key}")
         else:
             s3client.put_object(key=outgoing_key, content=outgoing_data)
 
@@ -513,7 +516,7 @@ def data_copy(*args, s3client):
     ) = args
     if task == "copy" and old_key is not None and new_key is not None:
         if DRY_RUN:
-            logger.info(f"Would copy: {old_key} -> {new_key}")
+            logger.debug(f"Would copy: {old_key} -> {new_key}")
         else:
             s3client.copy_object(old_key, new_key)
 

--- a/warehouse-loader/warehouse/warehouseloader.py
+++ b/warehouse-loader/warehouse/warehouseloader.py
@@ -25,6 +25,8 @@ logger.setLevel(logging.INFO)
 
 BUCKET_NAME = os.getenv("WAREHOUSE_BUCKET", default=None)
 DRY_RUN = bool(os.getenv("DRY_RUN", default=False))
+if DRY_RUN:
+    logger.info("This is a **dry run** with no file intended to be changed.")
 
 KB = 1024
 


### PR DESCRIPTION
Previous 2GB limit was too optimistic, the actual usage is somewhat higher than that, so bump things to the max allowed for 1vCPU Fargate tasks, to have buffer. Memory usage is pretty cheap and thus this will make things safer.

## Checklist

- [x] Changes have been tested
